### PR TITLE
use cabinet_shelf in project path and fix dir removal

### DIFF
--- a/spec/cabinet/file_system_spec.cr
+++ b/spec/cabinet/file_system_spec.cr
@@ -1,16 +1,10 @@
 require "../spec_helper"
 
 Spec.after_each do
-  dir = HI8.configuration.cabinet_shelf
-  match = dir.match(/(\.\/.*)\//)
-  if match
-    del_dir = match[0]
-    FileUtils.rm_r(del_dir) if Dir.exists?(del_dir)
-  end
+  empty_cabinet_shelf
 end
 
 describe HI8::Cabinet::FileSystem do
-
   it "stores a file" do
     shelf = "named.json"
     fs = HI8::Cabinet::FileSystem.new
@@ -45,5 +39,4 @@ describe HI8::Cabinet::FileSystem do
     fs.store(shelf, "")
     File.exists?(File.expand_path(File.join(HI8.configuration.cabinet_shelf, shelf))).should be_true
   end
-
 end

--- a/spec/deprecated_spec.cr
+++ b/spec/deprecated_spec.cr
@@ -1,5 +1,4 @@
-
 it "deprecates cassette_library_dir" do
-  HI8.configure {|conf| conf.cassette_library_dir = "/deprecated"}
-  HI8.configuration.cabinet_shelf.should eq "/deprecated"
+  HI8.configure { |conf| conf.cassette_library_dir = "./spec/deprecated" }
+  HI8.configuration.cabinet_shelf.should eq "./spec/deprecated"
 end

--- a/spec/hi8_spec.cr
+++ b/spec/hi8_spec.cr
@@ -2,12 +2,7 @@ require "./spec_helper"
 require "file_utils"
 
 Spec.after_each do
-  dir = HI8.configuration.cabinet_shelf
-  match = dir.match(/(\.\/.*)\//)
-  if match
-    del_dir = match[0]
-    FileUtils.rm_r(del_dir) if Dir.exists?(del_dir)
-  end
+  empty_cabinet_shelf
 end
 
 describe HI8 do
@@ -64,14 +59,14 @@ describe HI8 do
     HI8.use_cassette("query_mcstringerson", {:format_with => :yaml}) do
       request = HTTP::Client.get "http://www.example.net/resource?test=mctesterson&query=string"
       request.status_code.should eq 404
-      #for me this still shows exampel doemain even with the 404
+      # for me this still shows exampel doemain even with the 404
       request.body.should contain "Example Domain"
     end
     HI8.use_cassette("query_mcstringerson") do
       HI8.current_cassette.recorder.recording?.should be_false
       request = HTTP::Client.get "http://www.example.net/resource?test=mctesterson&query=string"
       request.status_code.should eq 404
-      #for me this still shows exampel doemain even with the 404
+      # for me this still shows exampel doemain even with the 404
       request.body.should contain "Example Domain"
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,4 +3,7 @@ require "../src/hi8"
 
 ASSETS = File.expand_path("#{File.dirname(__FILE__)}/assets")
 
-#pr = Process.new("spec/server", shell: true)
+def empty_cabinet_shelf
+  dir = HI8.configuration.cabinet_shelf
+  FileUtils.rm_r(dir) if Dir.exists?(dir)
+end


### PR DESCRIPTION
Hey @vonKingsley,

`/deprecated` wasn't accessible for me (in the root of the file system…) and the removal block removed relative paths within the project (`./spec/cassettes` removed all specs).

So this way the specs might be more portable.

And again: thank you for hi8!