### PR TITLE
Update deprecated methods for use with Crystal 1.9+

### DIFF
--- a/src/hi8/cassette.cr
+++ b/src/hi8/cassette.cr
@@ -52,7 +52,7 @@ module HI8
       {
         :episodes      => episodes_to_record.map(&.to_hash),
         :recorded_with => "HI8.CR #{HI8.version}",
-        :recorded_at   => Time.now.to_s,
+        :recorded_at   => Time.local.to_s,
       } of Symbol => String | Array(Hash(Symbol, Hash(Symbol, String | Hash(String, String))))
     end
 

--- a/src/hi8/formatters/json.cr
+++ b/src/hi8/formatters/json.cr
@@ -1,35 +1,35 @@
 require "json"
 
 class Request
-  JSON.mapping(
-    method: String,
-    uri: String,
-    body: String,
-    headers: Hash(String, String)
-  )
+  include JSON::Serializable
+
+  property method : String
+  property uri : String
+  property body : String
+  property headers : Hash(String, String)
 end
 
 class Response
-  JSON.mapping(
-    status: String,
-    headers: Hash(String, String),
-    body: String,
-    http_version: String
-  )
+  include JSON::Serializable
+
+  property status : String
+  property headers : Hash(String, String)
+  property body : String
+  property http_version : String
 end
 
 class Episode
-  JSON.mapping(
-    request: Request,
-    response: Response
-  )
+  include JSON::Serializable
+
+  property request : Request
+  property response : Response
 end
 
 class Episodes
-  JSON.mapping(
-    episodes: Array(Episode),
-    recorded_with: String
-  )
+  include JSON::Serializable
+
+  property episodes : Array(Episode)
+  property recorded_with : String
 end
 
 module HI8
@@ -45,10 +45,10 @@ module HI8
         hash.to_json
       end
 
-      def deserialize(string : String)
-        if string
-          Episodes.from_json(string)
-        end
+      def deserialize(string)
+        return unless string
+
+        Episodes.from_json(string)
       end
     end
   end

--- a/src/hi8/formatters/yaml.cr
+++ b/src/hi8/formatters/yaml.cr
@@ -1,35 +1,35 @@
 require "yaml"
 
 class Request
-  YAML.mapping(
-    method: String,
-    uri: String,
-    body: String,
-    headers: Hash(String, String)
-  )
+  include YAML::Serializable
+
+  property method : String
+  property uri : String
+  property body : String
+  property headers : Hash(String, String)
 end
 
 class Response
-  YAML.mapping(
-    status: String,
-    headers: Hash(String, String),
-    body: String,
-    http_version: String
-  )
+  include YAML::Serializable
+
+  property status : String
+  property headers : Hash(String, String)
+  property body : String
+  property http_version : String
 end
 
 class Episode
-  YAML.mapping(
-    request: Request,
-    response: Response
-  )
+  include YAML::Serializable
+
+  property request : Request
+  property response : Response
 end
 
 class Episodes
-  YAML.mapping(
-    episodes: Array(Episode),
-    recorded_with: String
-  )
+  include YAML::Serializable
+
+  property episodes : Array(Episode)
+  property recorded_with : String
 end
 
 module HI8


### PR DESCRIPTION
I've made some fixes to remove deprecated methods to make this shard usable with modern crystal (developed locally with crystal version `1.9.0`)

**Changes:**
- Refactored `json.cr` and `yaml.cr` formatter files to use respective Serializable classes instead of deprecated `mapping` methods
- Updated reference to deprecated `now` method on `Time` class to use `local` method instead
- Refactored `json.cr` to use a guard clause
